### PR TITLE
update hookrace to show nim blogs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ A curated list of awesome [Nim](https://nim-lang.org) frameworks, libraries and 
 
 * [Nim Blog](http://nim-lang.org/blog.html) - Official Nim blog.
 * [Goran Krampe](http://goran.krampe.se/nim/) - Wrapping C, arduino, performance, links.
-* [HookRace](http://hookrace.net) - Nim blog for now.
+* [HookRace](https://hookrace.net/blog/nim/) - Blog with multiple articles on Nim.
 * [Rants from the Ballmer Peak](https://gradha.github.io/index.html) - Posts on Nim and other languages.
 
 [**&DoubleUpArrow;**](#contents "Go to the top")


### PR DESCRIPTION
show nim blog posts when the link is clicked on